### PR TITLE
Edit画面open時_画像表示＆画像再選択時プレビュー

### DIFF
--- a/app/assets/javascripts/preview.js
+++ b/app/assets/javascripts/preview.js
@@ -2,9 +2,9 @@
 
 $(function(){
   $('.pic').change(function(){
-    console.log(this);
+    // console.log(this);
     var index = $('.pic').index(this);
-    console.log(index);
+    // console.log(index);
     $('.pic img').eq(index).remove();
     var file = $(this).prop('files')[0];
     if(!file.type.match('image.*')){

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -11,22 +11,25 @@
         .col-md-12
           %h4 Main Thumbnail
           .cover-image-upload#main_image_uploader
-            = f.fields_for :captured_images do |image|
+            = f.fields_for :captured_images, @prototype.captured_images.main.first do |image|
               / %img
               = image.file_field :content, required: true, :class => 'pic'
               = image.hidden_field :status, value: "main"
             .preview
+              - if @prototype.captured_images.main.first.present?
+                = image_tag(@prototype.captured_images.main.first.content, alt:"test", class:"resizeimage")
         .col-md-12
           %h4 Sub Thumbnails
           %ul.proto-sub-list.list-group
             - 3.times do |i|
               %li.list-group-item.col-md-4
                 .image-upload
-                  = f.fields_for :captured_images do |image|
+                  = f.fields_for :captured_images,@prototype.captured_images.sub[i] do |image|
                     / %img
                     = image.file_field :content, :class => 'pic'
                     = image.hidden_field :status, value: "sub"
                     .preview
+                      = image_tag(image.object.content, alt:"test", class:"resizeimage")
       .row.proto-description
         .col-md-12
           %h4 Catch Copy


### PR DESCRIPTION
# WHAT
Edit画面open時_画像表示されるように変更
画像を再選択時にプレビューさせるように変更

# WHY
Edit画面開いて、登録済みの画像が表示されてないのはおかしい
再選択時にもプレビューしないとわかりづらい